### PR TITLE
fix: 执行 sql 文件时，不能顺利创建好库和表

### DIFF
--- a/mysql-init/init.sql
+++ b/mysql-init/init.sql
@@ -1,6 +1,7 @@
+CREATE DATABASE IF NOT EXISTS `grtblog` DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 -- 修改数据库的字符集和排序规则
 ALTER DATABASE `grtblog` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
-
+USE `grtblog`;
 -- 创建用户表
 CREATE TABLE IF NOT EXISTS `user`
 (


### PR DESCRIPTION
加上以下语句，可执行完成：

```
USE `grtblog`;
```