### PR TITLE
fix(frontend):添加忘记密码的Link的onClick事件

### DIFF
--- a/frontend/src/components/user/LoginModal.tsx
+++ b/frontend/src/components/user/LoginModal.tsx
@@ -258,7 +258,8 @@ const LoginModal = ({isOpen, onClose}: { isOpen: boolean; onClose: () => void })
                                                     <div className="text-sm text-center">
                                                         忘记密码了？ <Link
                                                         href="/my/reset-password-request"
-                                                        color={"#184aff"}> 点击这里重置密码 </Link>
+                                                        color={"#184aff"}
+                                                        onClick={() => onClose()}> 点击这里重置密码 </Link>
                                                     </div>
                                                     <div className={styles.formActions}>
                                                         <Button style={{


### PR DESCRIPTION
原程序在login界面，点击忘记密码在此重置，会跳转到重置密码界面，但是login界面不会关掉，只需要在Link添加一个onClick事件即可
![image](https://github.com/user-attachments/assets/4c14930c-9913-450b-a3cd-0c43d1b2ecb2)
![image](https://github.com/user-attachments/assets/c33b4eac-ec45-421a-9943-744ab1e39fc9)